### PR TITLE
07-routes-and-navigation fix App Bar icons color on light mode theme

### DIFF
--- a/07-routes-and-navigation/projects/final/lib/fooderlich_theme.dart
+++ b/07-routes-and-navigation/projects/final/lib/fooderlich_theme.dart
@@ -68,6 +68,7 @@ class FooderlichTheme {
       appBarTheme: const AppBarTheme(
         foregroundColor: Colors.black,
         backgroundColor: Colors.white,
+        iconTheme: IconThemeData(color: Colors.black),
       ),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(
         foregroundColor: Colors.white,


### PR DESCRIPTION
in light mode theme icons on the AppBar is not showing in the android app due to the icon white color.
![Screenshot_2021-11-06-05-36-14-37](https://user-images.githubusercontent.com/58752042/140592000-d6283f99-269d-4d60-8104-573571bda957.png)

![Screenshot_2021-11-06-05-36-32-66](https://user-images.githubusercontent.com/58752042/140591986-a10b7666-73ed-4598-9941-25520ad08676.png)

after adding iconTheme to  `static ThemeData light()` in FooderlichTheme class
![Screenshot_2021-11-06-05-37-20-07](https://user-images.githubusercontent.com/58752042/140592205-82ec6325-729c-4539-8ae5-847b3151d397.png)

![Screenshot_2021-11-06-05-37-12-41](https://user-images.githubusercontent.com/58752042/140592214-ca24b462-871a-4a8c-9170-35a55dd693c6.png)

 