### PR TITLE
Update analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
 analyzer:
   exclude:
     - build/**


### PR DESCRIPTION
Includes `package:flutter_lints/flutter.yaml`, which is now used by default when creating a new Flutter project using SDK 3.*